### PR TITLE
TS test files not being found

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,9 @@
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [
-        "${workspaceFolder}/out"
-      ]
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+    "command": "npm",
+	"type": "shell",
+    "presentation": {
+        "echo": true,
+        "reveal": "silent",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+    },
+	"args": ["run", "build"],
+    "isBackground": true,
+	"problemMatcher": "$tsc-watch"
+}

--- a/src/JestManager.ts
+++ b/src/JestManager.ts
@@ -102,8 +102,9 @@ export default class JestManager {
       this.workspace.uri.fsPath,
       jestPath,
       configPath,
-      // TOOD: lookup version used in project
+      // TODO: lookup version used in project
       20,
+      "log",
       false,
       false,
     );

--- a/src/TestLoader.ts
+++ b/src/TestLoader.ts
@@ -109,6 +109,17 @@ export default class TestLoader {
   public async loadTests() {
     this.log.info(`Loading Jest settings from ${this.projectWorkspace.pathToConfig}`);
     const settings = new Settings(this.projectWorkspace);
+
+    // wrap the sync callback in a Promise
+    const getConfig = (): Promise<void> => {
+      return new Promise((resolve) => {
+        settings.getConfig(() => {
+          resolve();
+        });
+      });
+    };
+    // wait for Promise to return so we have the correct settings for testMatch and testRegex.
+    await getConfig();
     this.log.info("Jest settings loaded");
 
     this.log.info("Loading Jest tests");

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -198,8 +198,9 @@ export default class JestTestAdapter implements TestAdapter {
       this.workspace.uri.fsPath,
       jestPath,
       configPath,
-      // TOOD: lookup version used in project
+      // TODO: lookup version used in project
       20,
+      "log",
       false,
       false,
     );

--- a/src/helpers/pathToJest.ts
+++ b/src/helpers/pathToJest.ts
@@ -11,5 +11,8 @@ export default function pathToJest(workspace: WorkspaceFolder): string {
 }
 
 function pathToLocalJestExecutable(rootDir: string): string {
+  if (process.platform === "win32") {
+    return normalize(resolve(rootDir, "./node_modules/.bin/jest.cmd"));
+  }
   return normalize(resolve(rootDir, "./node_modules/.bin/jest"));
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,20 +10,20 @@ function getJestAdapterOptions(): IJestTestAdapterOptions {
   const pathToJest = (w: vscode.WorkspaceFolder) => {
     return (
       vscode.workspace
-        .getConfiguration("jestTestExplorer")
+        .getConfiguration("jestTestExplorer", null)
         .get<string>("pathToJest") || pathToJestHelper(w)
     );
   };
   const pathToConfig = () => {
     return (
       vscode.workspace
-        .getConfiguration("jestTestExplorer")
+        .getConfiguration("jestTestExplorer", null)
         .get<string>("pathToJestConfig") || pathToConfigHelper()
     );
   };
   return {
     debugOutput: vscode.workspace
-      .getConfiguration("jestTestExplorer")
+      .getConfiguration("jestTestExplorer", null)
       .get<DebugOutput>("debugOutput", DebugOutput.internalConsole),
     pathToConfig,
     pathToJest,
@@ -41,6 +41,8 @@ export async function activate(context: vscode.ExtensionContext) {
     "Jest Test Explorer Log",
   );
   context.subscriptions.push(log);
+
+  log.info("Jest Test Explorer activated");
 
   // get the Test Explorer extension
   const testExplorerExtension = vscode.extensions.getExtension<TestHub>(


### PR DESCRIPTION
Relates to #44

I have fixed some issues related to the discovery of tests, in particular TS tests.  The highlights are that the extension debugging experience should be working better and that the Jest config is now loaded correctly from the actual workspace and doesn't just rely on the defaults.